### PR TITLE
Allow successful empty response

### DIFF
--- a/FHIRServicesExternalModule.php
+++ b/FHIRServicesExternalModule.php
@@ -738,12 +738,8 @@ class FHIRServicesExternalModule extends \ExternalModules\AbstractExternalModule
         }
     }
     
-    function jsonSerialize($fhirObjectOrArrayOrNull){
-        if(is_null($fhirObjectOrArrayOrNull)){
-            $a = null;
-        } else {
-            $a = $this->toArray($fhirObjectOrArrayOrNull);
-        }
+    function jsonSerialize($fhirObjectOrArray){
+        $a = $this->toArray($fhirObjectOrArray);
         return json_encode($a, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES);
     }
 

--- a/send-record.php
+++ b/send-record.php
@@ -44,9 +44,15 @@ else if($action == 'validate'){
 header('Content-type: application/json'); 
 try{
     $response = $module->sendToRemoteFHIRServer($resource);
+    if(is_null($response)){
+        $remote_response = "";
+    } else {
+        $remote_response = $module->jsonSerialize($response);
+    }
+    
     echo json_encode([
         'message' => 'The remote FHIR server has confirmed that the data has been successfully received.',
-        'remote-response' => $module->jsonSerialize($response)
+        'remote-response' => $remote_response
     ]);
 }
 catch(\Throwable $t){


### PR DESCRIPTION
Dear @vanderbilt-redcap team, @mmcev106,

Thank you for your FHIR-module for REDCap.
We'd like to evaluate and use your FHIR extension in order to process and store survey forms on our FHIR server.

As a sidenote, we currently use the IBM FHIR Server from here: 
https://github.com/LinuxForHealth/FHIR
formerly https://github.com/IBM/FHIR

When sending the FHIR Bundle to the remote FHIR server, we got error messages due to the fact that the module tries to parse the response from the FHIR server. In our case, the FHIR server acknowledges the POST request with the HTTP status code 201, but response with an empty body.
Since the module expects a valid JSON-encoded Bundle as a response body and tries to parse the body in order to verify the resource type of the FHIR response, an exception is thrown.

In this PR we include the case for empty response data in which the module regards the empty response as valid if the response HTTP code propagates a successful response in the success range (200 <= \<status code\> < 300).

I'd like to know your feedback on this PR and whether it is addressing the pain point adequately.

Kind regards,
Johann