### PR TITLE
Only add Patient name/birthDate if provided

### DIFF
--- a/FHIRServicesExternalModule.php
+++ b/FHIRServicesExternalModule.php
@@ -2429,19 +2429,26 @@ class FHIRServicesExternalModule extends \ExternalModules\AbstractExternalModule
         $firstName = $args['firstName'];
         $lastName = $args['lastName'];
         $patientId = $args['patientId'];
+        $birthDate = $args['birthDate'];
 
-        $patient = $this->createResource('Patient', [
-            'id' => $patientId,
-            'name' => [
+        $patientObj = [
+            'id' => $patientId
+        ];
+
+        if(!is_null($firstName) && !is_null($lastName)){
+            $patientObj['name'] = [
                 [
-                    'given' => [
-                        $firstName
-                    ],
+                    'given' => [ $firstName ],
                     'family' => $lastName
                 ]
-            ],
-            'birthDate' => $args['birthDate']
-        ]);
+            ];
+        }
+
+        if(!is_null(birthDate)){
+            $patientObj['birthDate'] = $birthDate;
+        }
+
+        $patient = $this->createResource('Patient', $patientObj);
 
         $consent = $this->createResource('Consent', [
             'id' => $args['consentId'],


### PR DESCRIPTION
Hello @vanderbilt-redcap team, @mmcev106,

The FHIR Patient resource requires a valid name/birthDate if name/birthDate is given.
However, a Patient resource is also valid without name/birthDate, since both name and birthDate are optional.
https://www.hl7.org/fhir/patient.html

This pull request changes the code to only add these attributes if they are given. Otherwise, the attributes are not set.
Without these changes, the attributes will be set but their values are NULL, leading to an error message on the FHIR server.

Please tell me whether the PR is of sufficient quality or whether something needs to be improved.

Kind regards,
Johann