### PR TITLE
Add option to send cleaned eConsent FHIR bundle

### DIFF
--- a/FHIRServicesExternalModule.php
+++ b/FHIRServicesExternalModule.php
@@ -2428,19 +2428,37 @@ class FHIRServicesExternalModule extends \ExternalModules\AbstractExternalModule
         $firstName = $args['firstName'];
         $lastName = $args['lastName'];
         $patientId = $args['patientId'];
+        $birthDate = $args['birthDate'];
 
-        $patient = $this->createResource('Patient', [
-            'id' => $patientId,
-            'name' => [
+        $patientObj = [
+            'id' => $patientId
+        ];
+
+        $allow_cleaned_consent_bundle = $this->getProjectSetting('allow-consent-bundle-cleanup');
+
+        // Set attributes only if not null
+        if(is_null($firstName) || is_null($lastName)){
+            if(!$allow_cleaned_consent_bundle){
+                throw new \Exception('eConsent FHIR name attribute is null.');
+            }
+        } else {
+            $patientObj['name'] = [
                 [
-                    'given' => [
-                        $firstName
-                    ],
+                    'given' => [ $firstName ],
                     'family' => $lastName
                 ]
-            ],
-            'birthDate' => $args['birthDate']
-        ]);
+            ];
+        }
+
+        if(is_null($birthDate)){
+            if(!$allow_cleaned_consent_bundle){
+                throw new \Exception('eConsent FHIR birthDate attribute is null.');
+            }
+        } else {
+            $patientObj['birthDate'] = $birthDate;
+        }
+
+        $patient = $this->createResource('Patient', $patientObj);
 
         $consent = $this->createResource('Consent', [
             'id' => $args['consentId'],

--- a/FHIRServicesExternalModule.php
+++ b/FHIRServicesExternalModule.php
@@ -2434,22 +2434,35 @@ class FHIRServicesExternalModule extends \ExternalModules\AbstractExternalModule
             'id' => $patientId
         ];
 
-        $allow_cleaned_consent_bundle = $this->getProjectSetting('allow-consent-bundle-cleanup');
+        $allow_cleaned_consent_bundle = $this->getProjectSetting('remove-blank-econsent-identifiers');
 
-        // Set attributes only if not null
-        if(is_null($firstName) || is_null($lastName)){
+        // Initialize name attribute only if first name and last name are not null
+        if(is_null($firstName) && is_null($lastName)){
             if(!$allow_cleaned_consent_bundle){
-                throw new \Exception('eConsent FHIR name attribute is null.');
+                throw new \Exception('eConsent first name and last name attributes are null.');
             }
         } else {
-            $patientObj['name'] = [
-                [
-                    'given' => [ $firstName ],
-                    'family' => $lastName
-                ]
-            ];
+            // Create (list of) empty name object (=array of array) to fill
+            $patientObj['name'] = [ array() ];
         }
 
+        // Fill first name if given
+        if(is_null($firstName)){
+            if(!$allow_cleaned_consent_bundle){
+                throw new \Exception('eConsent FHIR firstName attribute is null.');
+            }
+        } else {
+            $patientObj['name'][0]["given"] = [ $firstName ];
+        }
+        // Fill last name if given
+        if(is_null($lastName)){
+            if(!$allow_cleaned_consent_bundle){
+                throw new \Exception('eConsent FHIR lastName attribute is null.');
+            }
+        } else {
+            $patientObj['family'] = $lastName;
+        }
+    
         if(is_null($birthDate)){
             if(!$allow_cleaned_consent_bundle){
                 throw new \Exception('eConsent FHIR birthDate attribute is null.');

--- a/FHIRServicesExternalModule.php
+++ b/FHIRServicesExternalModule.php
@@ -2460,7 +2460,7 @@ class FHIRServicesExternalModule extends \ExternalModules\AbstractExternalModule
                 throw new \Exception('eConsent FHIR lastName attribute is null.');
             }
         } else {
-            $patientObj['family'] = $lastName;
+            $patientObj['name'][0]['family'] = $lastName;
         }
     
         if(is_null($birthDate)){

--- a/config.json
+++ b/config.json
@@ -67,6 +67,11 @@
             "type": "checkbox"
         },
         {
+            "key": "allow-consent-bundle-cleanup",
+            "name": "Allow and clean eConsents messages to the Remote FHIR Server with invalid birth date or name attributes",
+            "type": "checkbox"
+        },
+        {
 			"key": "project-type",
 			"name": "<b>Project Type</b> - This setting should be left blank in most cases",
 			"type": "dropdown",
@@ -112,7 +117,7 @@
                         {
                             "name" : "Treatment",
                             "value" : "treatment"
-                        }   
+                        }
                     ]
                 },
                 {

--- a/config.json
+++ b/config.json
@@ -67,8 +67,8 @@
             "type": "checkbox"
         },
         {
-            "key": "allow-consent-bundle-cleanup",
-            "name": "Allow and clean eConsents messages to the Remote FHIR Server with invalid birth date or name attributes",
+            "key": "remove-blank-econsent-identifiers",
+            "name": "Remove blank identifiers from eConsents",
             "type": "checkbox"
         },
         {


### PR DESCRIPTION
Hello @mmcev106,

I've tried to implement the idea that we developed in #5.
In essence, there is an option in the project settings to allow the FHIR bundle cleanup of null values for name and birthDate for eConsent messages to the remote FHIR server.
I'm interested in your feedback and would like to know whether this is something that is acceptable for merge?
Feel free to change any string texts or constants at will.

Kind regards,
Johann